### PR TITLE
Add user credentials to CoreServiceSettings and Client

### DIFF
--- a/CoreService/Client.psm1
+++ b/CoreService/Client.psm1
@@ -134,7 +134,7 @@ Function Get-CoreServiceClient
     {
         try
         {
-			$proxy = [Activator]::CreateInstance($instanceType, $binding, $endpoint);
+            $proxy = [Activator]::CreateInstance($instanceType.FullName, $binding, $endpoint);
             if($serviceInfo.Username -and $serviceInfo.Password)
             {
                 Write-Verbose "Using credentials of CoreServiceSettings";

--- a/CoreService/Client.psm1
+++ b/CoreService/Client.psm1
@@ -123,6 +123,7 @@ Function Get-CoreServiceClient
         $binding = Get-CoreServiceBinding;
 		
 		#Load the assembly without locking the file
+        Write-Verbose ("Loading assembly {0}" -f $serviceInfo.AssemblyPath) 
 		$assemblyBytes = [IO.File]::ReadAllBytes($serviceInfo.AssemblyPath);
 		if (!$assemblyBytes) { throw "Unable to load the assembly at: " + $serviceInfo.AssemblyPath; }
         $assembly = [Reflection.Assembly]::Load($assemblyBytes);

--- a/CoreService/Client.psm1
+++ b/CoreService/Client.psm1
@@ -135,6 +135,13 @@ Function Get-CoreServiceClient
         try
         {
 			$proxy = [Activator]::CreateInstance($instanceType, $binding, $endpoint);
+            if($serviceInfo.Username -and $serviceInfo.Password)
+            {
+                Write-Verbose "Using credentials of CoreServiceSettings";
+                
+				$proxy.ClientCredentials.Windows.ClientCredential.UserName = $serviceInfo.Username;
+				$proxy.ClientCredentials.Windows.ClientCredential.Password = $serviceInfo.Password;
+            }
 
 			if ($ImpersonateUserName)
 			{

--- a/CoreService/Settings.psm1
+++ b/CoreService/Settings.psm1
@@ -46,6 +46,7 @@ Function Get-DefaultSettings
 		"ConnectionSendTimeout" = "00:01:00";
 		"HostName" = "localhost";
 		"UserName" = ([Environment]::UserDomainName + "\" + [Environment]::UserName);
+        "Password" = "";
 		"Version" = "2011-SP1";
 		"ConnectionType" = "Default";
 		"ModuleVersion" = $moduleVersion;
@@ -123,7 +124,11 @@ Function Save-Settings($settings)
 				New-Item -Path $settingsDir -ItemType Container | Out-Null
 			}
 			
+            #todo Find a more elegant way to prevent saving the password to the settings file
+            $password = $settings.Password
+            $settings.Password = ""
 			Export-Clixml -Path $settingsFile -InputObject $settings;
+    		$settings.Password = $password
 			$script:Settings = $settings;
 		}
 		catch
@@ -183,6 +188,9 @@ Function Set-CoreServiceSettings
 		[Parameter()]
 		[string]$UserName,
 		
+		[Parameter()]
+		[string]$Password,
+		
 		[ValidateSet('', 'Default', 'SSL', 'LDAP', 'LDAP-SSL', 'netTcp')]
 		[Parameter()]
 		[string]$ConnectionType,
@@ -198,6 +206,7 @@ Function Set-CoreServiceSettings
     {
 		$hostNameSpecified = (![string]::IsNullOrEmpty($HostName));
 		$userNameSpecified = (![string]::IsNullOrEmpty($UserName));
+        $passwordSpecified = (![string]::IsNullOrEmpty($Password));
 		$versionSpecified = (![string]::IsNullOrEmpty($Version));
 		$connectionTypeSpecified = (![string]::IsNullOrEmpty($ConnectionType));
 		$connectionSendTimeoutSpecified = (![string]::IsNullOrEmpty($ConnectionSendTimeout));
@@ -207,6 +216,7 @@ Function Set-CoreServiceSettings
 		if ($connectionSendTimeoutSpecified) { $settings.ConnectionSendTimeout = $ConnectionSendTimeout; }
 		if ($hostNameSpecified) { $settings.HostName = $HostName; }
 		if ($userNameSpecified) { $settings.UserName = $UserName; }
+        if ($passwordSpecified) { $settings.Password = $Password; }
 		if ($versionSpecified) { $settings.Version = $Version; }
 
 		if ($versionSpecified -or $hostNameSpecified -or $connectionTypeSpecified)

--- a/CoreService/Settings.psm1
+++ b/CoreService/Settings.psm1
@@ -260,6 +260,24 @@ Function Set-CoreServiceSettings
     }
 }
 
+Function Clear-CoreServiceSettings
+{
+    <#
+    .Synopsis
+    Gets the settings used to connect to the Core Service.
+
+    .Link
+    Get the latest version of this script from the following URL:
+    https://github.com/pkjaer/tridion-powershell-modules
+	#>
+    [CmdletBinding()]
+    Param()
+	
+	Process {
+        $settings = Get-DefaultSettings
+        Save-Settings $settings
+    }
+}
 
 <#
 **************************************************
@@ -268,3 +286,4 @@ Function Set-CoreServiceSettings
 #>
 Export-ModuleMember Get-CoreServiceSettings;
 Export-ModuleMember Set-CoreServiceSettings;
+Export-ModuleMember Clear-CoreServiceSettings;


### PR DESCRIPTION
Adding the option to enter username and password in the CoreServiceSettings. These credentials will be used instead of the logged in user's credentials.

Needed to change the way the $proxy is setup in Client.psm1, the old style would not work with the credenitals.