### PR TITLE
Hard coded the max value for MaxReceiveMessageSize

### DIFF
--- a/CoreService/Client.psm1
+++ b/CoreService/Client.psm1
@@ -52,7 +52,7 @@ Function Get-CoreServiceBinding
 	}
 	
 	$binding.SendTimeout = $settings.ConnectionSendTimeout;
-	$binding.MaxReceivedMessageSize = 10485760;
+	$binding.MaxReceivedMessageSize = [long]::MaxValue;
 	$binding.ReaderQuotas = $quotas;
 	return $binding;
 }


### PR DESCRIPTION
I started by making this configurable, but that's just adding complexity for no reason. This version just hard codes it to the max value. This quota is only to prevent dos attacks, so assuming we're only ever going to use the module to talk to genuine Tridion core services, we don't really need any limit here. If you really want the other version, it's on another branch, but my view is that this rather simple hack is a better solution. 