### PR TITLE
Removed the ability to specify your own prefix for the modules

### DIFF
--- a/Alchemy/Plugins.psm1
+++ b/Alchemy/Plugins.psm1
@@ -72,7 +72,7 @@ Function GetMonitorJobs($Folder = $null)
 **************************************************
 #>
 
-Function Get-PluginNameFromFile
+Function Get-AlchemyPluginNameFromFile
 {
     [CmdletBinding()]
     Param(
@@ -117,14 +117,14 @@ Function Get-PluginNameFromFile
 	}
 }
 
-Function Get-Plugins
+Function Get-AlchemyPlugins
 {
     [CmdletBinding()]
     Param()
 	
 	Process
 	{
-		$settings = Get-ConnectionSettings;
+		$settings = Get-AlchemyConnectionSettings;
 		$client = GetClient -Credentials $settings.Credentials;
 		$server = NormalizeServerUrl $settings.Host;
 		
@@ -140,7 +140,7 @@ Function Get-Plugins
 	}
 }
 
-Function Install-Plugin
+Function Install-AlchemyPlugin
 {
     [CmdletBinding()]
     Param(
@@ -154,14 +154,14 @@ Function Install-Plugin
 	Process
 	{
 		$verboseRequested = ($PSBoundParameters['Verbose'] -eq $true);
-		$settings = Get-ConnectionSettings;
+		$settings = Get-AlchemyConnectionSettings;
 		
-		$name = Get-PluginNameFromFile $File
+		$name = Get-AlchemyPluginNameFromFile $File
 		$nameWithSpaces = $name.Replace('_', ' ');
 
 		if (!$Force)
 		{
-			$installedPlugins = Get-Plugins -Verbose:$verboseRequested | Where { $_.name -eq $nameWithSpaces };
+			$installedPlugins = Get-AlchemyPlugins -Verbose:$verboseRequested | Where { $_.name -eq $nameWithSpaces };
 			if ($installedPlugins.Count -gt 0)
 			{
 				Write-Warning "'$nameWithSpaces' is already installed.";
@@ -180,7 +180,7 @@ Function Install-Plugin
 	}
 }
 
-Function Uninstall-Plugin
+Function Uninstall-AlchemyPlugin
 {
     [CmdletBinding()]
     Param(
@@ -197,19 +197,19 @@ Function Uninstall-Plugin
 	Process
 	{
 		$verboseRequested = ($PSBoundParameters['Verbose'] -eq $true);
-		$settings = Get-ConnectionSettings;
+		$settings = Get-AlchemyConnectionSettings;
 		$name = $Name;
 		
 		if ($File)
 		{
 			Write-Verbose "Reading the plugin name from file...";
-			$name = Get-PluginNameFromFile $File -Verbose:$verboseRequested;
+			$name = Get-AlchemyPluginNameFromFile $File -Verbose:$verboseRequested;
 		}
 		$nameWithSpaces = $name.Replace('_', ' ');
 
 		if (!$Force)
 		{
-			$installedPlugins = Get-Plugins -Verbose:$verboseRequested | Where { $_.name -eq $nameWithSpaces };
+			$installedPlugins = Get-AlchemyPlugins -Verbose:$verboseRequested | Where { $_.name -eq $nameWithSpaces };
 			if ($installedPlugins.Count -lt 1)
 			{
 				Write-Verbose "'$nameWithSpaces' is not currently installed.";
@@ -227,7 +227,7 @@ Function Uninstall-Plugin
 	}
 }
 
-Function Update-Plugin
+Function Update-AlchemyPlugin
 {
     [CmdletBinding()]
     Param(
@@ -245,9 +245,9 @@ Function Update-Plugin
 		try
 		{
 			Write-Progress -Activity "Updating plugin" -Status "Uninstalling $File" -PercentComplete 10;
-			Uninstall-Plugin -File $File -Verbose:$verboseRequested -Force:$Force
+			Uninstall-AlchemyPlugin -File $File -Verbose:$verboseRequested -Force:$Force
 			Write-Progress -Activity "Updating plugin" -Status "Uninstalling $File" -PercentComplete 50;
-			Install-Plugin -File $File -Verbose:$verboseRequested -Force:$Force
+			Install-AlchemyPlugin -File $File -Verbose:$verboseRequested -Force:$Force
 			Write-Progress -Activity "Updating plugin" -Status "Done updating $File" -PercentComplete 10 -Completed;
 		}
 		catch
@@ -258,7 +258,7 @@ Function Update-Plugin
 }
 }
 
-Function Start-PluginMonitor
+Function Start-AlchemyPluginMonitor
 {
     [CmdletBinding()]
     Param(
@@ -301,7 +301,7 @@ Function Start-PluginMonitor
 			
 			if ($update)
 			{
-				Update-Plugin -File $fileName -Verbose:$messageData.Verbose -Force:$force
+				Update-AlchemyPlugin -File $fileName -Verbose:$messageData.Verbose -Force:$force
 			}
 		};
 
@@ -311,7 +311,7 @@ Function Start-PluginMonitor
 	}
 }
 
-Function Stop-PluginMonitor
+Function Stop-AlchemyPluginMonitor
 {
     [CmdletBinding()]
     Param()
@@ -338,10 +338,10 @@ Function Stop-PluginMonitor
 * Export statements
 **************************************************
 #>
-Export-ModuleMember Get-PluginNameFromFile
-Export-ModuleMember Get-Plugins
-Export-ModuleMember Install-Plugin
-Export-ModuleMember Uninstall-Plugin
-Export-ModuleMember Update-Plugin
-Export-ModuleMember Start-PluginMonitor
-Export-ModuleMember Stop-PluginMonitor
+Export-ModuleMember Get-AlchemyPluginNameFromFile
+Export-ModuleMember Get-AlchemyPlugins
+Export-ModuleMember Install-AlchemyPlugin
+Export-ModuleMember Uninstall-AlchemyPlugin
+Export-ModuleMember Update-AlchemyPlugin
+Export-ModuleMember Start-AlchemyPluginMonitor
+Export-ModuleMember Stop-AlchemyPluginMonitor

--- a/Alchemy/Settings.psm1
+++ b/Alchemy/Settings.psm1
@@ -116,7 +116,7 @@ Function Save-Settings($settings)
 **************************************************
 #>
 
-Function Get-ConnectionSettings
+Function Get-AlchemyConnectionSettings
 {
     <#
     .Synopsis
@@ -132,7 +132,7 @@ Function Get-ConnectionSettings
 	Process { return Get-Settings; }
 }
 
-Function Set-ConnectionSettings
+Function Set-AlchemyConnectionSettings
 {
     <#
     .Synopsis
@@ -185,5 +185,5 @@ Function Set-ConnectionSettings
 * Export statements
 **************************************************
 #>
-Export-ModuleMember Get-ConnectionSettings;
-Export-ModuleMember Set-ConnectionSettings;
+Export-ModuleMember Get-AlchemyConnectionSettings;
+Export-ModuleMember Set-AlchemyConnectionSettings;

--- a/Alchemy/Tridion-Alchemy.psd1
+++ b/Alchemy/Tridion-Alchemy.psd1
@@ -85,7 +85,5 @@ FileList = @("Plugins.psm1", "Settings.psm1")
 
 # Private data to pass to the module specified in ModuleToProcess
 PrivateData = ''
-
-DefaultCommandPrefix = 'Alchemy'
 }
 

--- a/ContentDelivery/Services.psm1
+++ b/ContentDelivery/Services.psm1
@@ -31,7 +31,7 @@ Function New-ObjectWithProperties([Hashtable]$properties)
 **************************************************
 #>
 
-function Get-ContentDeliveryToken
+function Get-TridionContentDeliveryToken
 {
     <#
     .Synopsis
@@ -102,7 +102,7 @@ function Get-ContentDeliveryToken
 	}
 }
 
-function Test-ContentDeliveryServices
+function Test-TridionContentDeliveryServices
 {
     <#
     .Synopsis
@@ -251,5 +251,5 @@ function Test-ContentDeliveryServices
 * Export statements
 **************************************************
 #>
-Export-ModuleMember Get-ContentDeliveryToken
-Export-ModuleMember Test-ContentDeliveryServices
+Export-ModuleMember Get-TridionContentDeliveryToken
+Export-ModuleMember Test-TridionContentDeliveryServices

--- a/ContentDelivery/Tridion-ContentDelivery.psd1
+++ b/ContentDelivery/Tridion-ContentDelivery.psd1
@@ -85,7 +85,5 @@ FileList = @("Services.psm1")
 
 # Private data to pass to the module specified in ModuleToProcess
 PrivateData = ''
-
-DefaultCommandPrefix = 'Tridion'
 }
 

--- a/CoreService/AppData.psm1
+++ b/CoreService/AppData.psm1
@@ -6,14 +6,19 @@
 **************************************************
 #>
 
-Function Convert-ApplicationData
+<#
+**************************************************
+* Public members
+**************************************************
+#>
+Function Convert-TridionApplicationData
 {
     <#
     .Synopsis
     Converts the byte values of a piece of Application Data to a string.
 
     .Inputs
-    The Application Data object, as returned by Get-ApplicationData.
+    The Application Data object, as returned by Get-TridionApplicationData.
 
     .Outputs
     Returns the value of the application data as a string.
@@ -64,12 +69,7 @@ Function Convert-ApplicationData
 }
 
 
-<#
-**************************************************
-* Public members
-**************************************************
-#>
-Function Get-ApplicationData
+Function Get-TridionApplicationData
 {
     <#
     .Synopsis
@@ -105,7 +105,7 @@ Function Get-ApplicationData
 	
 	Begin
 	{
-		$client = Get-CoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
+		$client = Get-TridionCoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
 	}
 	
     Process
@@ -127,11 +127,11 @@ Function Get-ApplicationData
 	
 	End
 	{
-		Close-CoreServiceClient $client;
+		Close-TridionCoreServiceClient $client;
 	}
 }
 
-Function Set-ApplicationData
+Function Set-TridionApplicationData
 {
     <#
     .Synopsis
@@ -179,7 +179,7 @@ Function Set-ApplicationData
 	
 	Begin
 	{
-		$client = Get-CoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
+		$client = Get-TridionCoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
 	}
 	
     Process
@@ -207,11 +207,11 @@ Function Set-ApplicationData
 	
 	End
 	{
-		Close-CoreServiceClient $client;
+		Close-TridionCoreServiceClient $client;
 	}
 }
 
-Function Remove-ApplicationData
+Function Remove-TridionApplicationData
 {
     <#
     .Synopsis
@@ -241,7 +241,7 @@ Function Remove-ApplicationData
 	
 	Begin
 	{
-		$client = Get-CoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
+		$client = Get-TridionCoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
 	}
 	
     Process
@@ -257,7 +257,7 @@ Function Remove-ApplicationData
 	
 	End
 	{
-		Close-CoreServiceClient $client;
+		Close-TridionCoreServiceClient $client;
 	}
 }
 
@@ -266,7 +266,7 @@ Function Remove-ApplicationData
 * Export statements
 **************************************************
 #>
-Export-ModuleMember Get-ApplicationData
-Export-ModuleMember Set-ApplicationData
-Export-ModuleMember Remove-ApplicationData
-Export-ModuleMember Convert-ApplicationData
+Export-ModuleMember Convert-TridionApplicationData
+Export-ModuleMember Get-TridionApplicationData
+Export-ModuleMember Set-TridionApplicationData
+Export-ModuleMember Remove-TridionApplicationData

--- a/CoreService/Client.psm1
+++ b/CoreService/Client.psm1
@@ -8,7 +8,7 @@
 
 Function Get-CoreServiceBinding
 {
-	$settings = Get-CoreServiceSettings
+	$settings = Get-TridionCoreServiceSettings
 
 	$quotas = New-Object System.Xml.XmlDictionaryReaderQuotas;
 	$quotas.MaxStringContentLength = 10485760;
@@ -63,7 +63,7 @@ Function Get-CoreServiceBinding
 * Public members
 **************************************************
 #>
-Function Get-CoreServiceClient
+Function Get-TridionCoreServiceClient
 {
     <#
     .Synopsis
@@ -114,7 +114,7 @@ Function Get-CoreServiceClient
         Add-Type -AssemblyName System.ServiceModel
 
         # Load information about the Core Service client available on this system
-        $serviceInfo = Get-CoreServiceSettings
+        $serviceInfo = Get-TridionCoreServiceSettings
         
         Write-Verbose ("Connecting to the Core Service at {0}..." -f $serviceInfo.HostName);
         
@@ -157,7 +157,7 @@ Function Get-CoreServiceClient
     }
 }
 
-Function Close-CoreServiceClient
+Function Close-TridionCoreServiceClient
 {
     <#
     .Synopsis
@@ -219,5 +219,5 @@ Function Close-CoreServiceClient
 * Export statements
 **************************************************
 #>
-Export-ModuleMember Get-CoreServiceClient
-Export-ModuleMember Close-CoreServiceClient
+Export-ModuleMember Get-TridionCoreServiceClient
+Export-ModuleMember Close-TridionCoreServiceClient

--- a/CoreService/Installation/Install-Local.ps1
+++ b/CoreService/Installation/Install-Local.ps1
@@ -41,9 +41,7 @@ function EnsureDirectoriesExist
 	foreach($dir in $directories)
 	{
 		$path = Join-Path $baseDir $dir;
-		
-		#Note: Using the full name of the New-Item cmdlet here because the New-TridionItem function conflicts with it within this module.
-		Microsoft.PowerShell.Management\New-Item -Path $path -ItemType Directory -Force | Out-Null;
+		New-Item -Path $path -ItemType Directory -Force | Out-Null;
 		
 		if (!(Test-Path $path))
 		{

--- a/CoreService/Items.psm1
+++ b/CoreService/Items.psm1
@@ -12,7 +12,7 @@
 * Public members
 **************************************************
 #>
-function Get-Publications
+function Get-TridionPublications
 {
     <#
     .Synopsis
@@ -58,7 +58,7 @@ function Get-Publications
 	
 	Begin
 	{
-        $client = Get-CoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
+        $client = Get-TridionCoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
 	}
 	
     Process
@@ -77,11 +77,11 @@ function Get-Publications
 	
 	End
 	{
-		Close-CoreServiceClient $client;
+		Close-TridionCoreServiceClient $client;
 	}
 }
 
-function Get-PublicationTargets
+function Get-TridionPublicationTargets
 {
     <#
     .Synopsis
@@ -107,7 +107,7 @@ function Get-PublicationTargets
 	
 	Begin
 	{
-        $client = Get-CoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
+        $client = Get-TridionCoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
 	}
 	
     Process
@@ -122,11 +122,11 @@ function Get-PublicationTargets
 	
 	End
 	{
-		Close-CoreServiceClient $client;
+		Close-TridionCoreServiceClient $client;
 	}
 }
 
-function Get-PublicationTarget
+function Get-TridionPublicationTarget
 {
     <#
     .Synopsis
@@ -183,7 +183,7 @@ function Get-PublicationTarget
 				}
 
 				Write-Verbose "Loading Publication Target with ID '$Id'..."
-				$result = Get-Item $Id -ErrorAction SilentlyContinue;
+				$result = Get-TridionItem $Id -ErrorAction SilentlyContinue;
 				if (-not $result)
 				{
 					Write-Error "Publication Target '$Id' does not exist.";
@@ -195,7 +195,7 @@ function Get-PublicationTarget
 			'ByTitle'
 			{
 				Write-Verbose "Loading Publication Target with title '$Title'..."
-				$result = Get-PublicationTargets | ?{$_.Title -eq $Title} | Select -First 1;
+				$result = Get-TridionPublicationTargets | ?{$_.Title -eq $Title} | Select -First 1;
 				if (-not $result)
 				{
 					Write-Error "There is no Publication Target named '$Title'.";
@@ -207,7 +207,7 @@ function Get-PublicationTarget
 	}
 }
 
-Function Get-Item
+Function Get-TridionItem
 {
     <#
     .Synopsis
@@ -257,7 +257,7 @@ Function Get-Item
 	
 	Begin
 	{
-		$client = Get-CoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
+		$client = Get-TridionCoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
 	}
 	
     Process
@@ -277,11 +277,11 @@ Function Get-Item
 	
 	End
 	{
-		Close-CoreServiceClient $client;
+		Close-TridionCoreServiceClient $client;
 	}
 }
 
-function Test-Item
+function Test-TridionItem
 {
     <#
     .Synopsis
@@ -321,7 +321,7 @@ function Test-Item
 	
 	Begin
 	{
-		$client = Get-CoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
+		$client = Get-TridionCoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
 	}
 	
     Process
@@ -331,11 +331,11 @@ function Test-Item
 	
 	End
 	{
-		Close-CoreServiceClient $client;
+		Close-TridionCoreServiceClient $client;
 	}
 }
 
-function New-Item
+function New-TridionItem
 {
     <#
     .Synopsis
@@ -380,7 +380,7 @@ function New-Item
 	
 	Begin
 	{
-		$client = Get-CoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
+		$client = Get-TridionCoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
 	}
 	
     Process
@@ -399,12 +399,12 @@ function New-Item
 	
 	End
 	{
-		Close-CoreServiceClient $client;
+		Close-TridionCoreServiceClient $client;
 	}
 }
 
 
-function New-Publication
+function New-TridionPublication
 {
     <#
     .Synopsis
@@ -444,7 +444,7 @@ function New-Publication
 	
 	Begin
 	{
-		$client = Get-CoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
+		$client = Get-TridionCoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
 	}
 	
     Process
@@ -475,11 +475,11 @@ function New-Publication
 	
 	End
 	{
-		Close-CoreServiceClient $client;
+		Close-TridionCoreServiceClient $client;
 	}
 }
 
-function Remove-Item
+function Remove-TridionItem
 {
     <#
     .Synopsis
@@ -519,7 +519,7 @@ function Remove-Item
 	
 	Begin
 	{
-		$client = Get-CoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
+		$client = Get-TridionCoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
 	}
 	
     Process
@@ -544,7 +544,7 @@ function Remove-Item
 	
 	End
 	{
-		Close-CoreServiceClient $client;
+		Close-TridionCoreServiceClient $client;
 	}
 }
 
@@ -554,11 +554,11 @@ function Remove-Item
 * Export statements
 **************************************************
 #>
-Export-ModuleMember Get-Item
-Export-ModuleMember Get-Publications
-Export-ModuleMember Get-PublicationTarget
-Export-ModuleMember Get-PublicationTargets
-Export-ModuleMember New-Item
-Export-ModuleMember New-Publication
-Export-ModuleMember Test-Item
-Export-ModuleMember Remove-Item
+Export-ModuleMember Get-TridionItem
+Export-ModuleMember Get-TridionPublications
+Export-ModuleMember Get-TridionPublicationTarget
+Export-ModuleMember Get-TridionPublicationTargets
+Export-ModuleMember New-TridionItem
+Export-ModuleMember New-TridionPublication
+Export-ModuleMember Test-TridionItem
+Export-ModuleMember Remove-TridionItem

--- a/CoreService/Publishing.psm1
+++ b/CoreService/Publishing.psm1
@@ -12,7 +12,7 @@
 * Public members
 **************************************************
 #>
-function Publish-Item
+function Publish-TridionItem
 {
     <#
     .Synopsis
@@ -72,7 +72,7 @@ function Publish-Item
 	
 	Begin
 	{
-		$client = Get-CoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
+		$client = Get-TridionCoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
 	}
 	
     Process
@@ -100,11 +100,11 @@ function Publish-Item
 	
 	End
 	{
-		Close-CoreServiceClient $client;
+		Close-TridionCoreServiceClient $client;
 	}
 }
 
-function Get-PublishTransaction
+function Get-TridionPublishTransaction
 {
     <#
     .Synopsis
@@ -148,7 +148,7 @@ function Get-PublishTransaction
     Returns all Publish Transactions created by user 'domain\name' that were published successfully.
 
     .Example
-    Get-TridionPublishTransaction -Priority Low | Remove-PublishTransactions
+    Get-TridionPublishTransaction -Priority Low | Remove-TridionPublishTransactions
     Removes all Publish Transactions with a low priority.
 
     #>
@@ -187,7 +187,7 @@ function Get-PublishTransaction
 
     Begin
 	{
-        $client = Get-CoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
+        $client = Get-TridionCoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
     }
 
     Process
@@ -198,7 +198,7 @@ function Get-PublishTransaction
 			{
 				'ById'
 				{
-					return Get-Item $Id;
+					return Get-TridionItem $Id;
 				}
 				
 				'ByFilter'
@@ -263,13 +263,11 @@ function Get-PublishTransaction
 
     End
 	{
-		Close-CoreServiceClient $client;
+		Close-TridionCoreServiceClient $client;
 	}
-
-
 }
 
-function Remove-PublishTransaction
+function Remove-TridionPublishTransaction
 {
     <#
     .Synopsis
@@ -291,11 +289,11 @@ function Remove-PublishTransaction
     https://github.com/pkjaer/tridion-powershell-modules
 	
     .Example
-    Remove-PublishTransactions tcm:0-4212900-66560
+    Remove-TridionPublishTransactions tcm:0-4212900-66560
     Remove a Publish Transaction with this uri from the Publish Queue
 
     .Example
-    Get-PublishQueueInfo -Priority Low -NoFormatting | select -ExpandProperty Id | Remove-PublishTransactions
+    Get-PublishQueueInfo -Priority Low -NoFormatting | select -ExpandProperty Id | Remove-TridionPublishTransactions
     Remove all Publish Transactions with a low priority
     #>
 
@@ -311,7 +309,7 @@ function Remove-PublishTransaction
 
     Begin
 	{
-        $client = Get-CoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
+        $client = Get-TridionCoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
     }
     Process
     {
@@ -334,7 +332,7 @@ function Remove-PublishTransaction
 
     End
 	{
-		Close-CoreServiceClient $client;
+		Close-TridionCoreServiceClient $client;
 	}
 
 }
@@ -346,6 +344,6 @@ function Remove-PublishTransaction
 * Export statements
 **************************************************
 #>
-Export-ModuleMember Publish-Item
-Export-ModuleMember Get-PublishTransaction
-Export-ModuleMember Remove-PublishTransaction
+Export-ModuleMember Publish-TridionItem
+Export-ModuleMember Get-TridionPublishTransaction
+Export-ModuleMember Remove-TridionPublishTransaction

--- a/CoreService/Settings.psm1
+++ b/CoreService/Settings.psm1
@@ -150,7 +150,7 @@ Function Save-Settings($settings)
 **************************************************
 #>
 
-Function Get-CoreServiceSettings
+Function Get-TridionCoreServiceSettings
 {
     <#
     .Synopsis
@@ -166,7 +166,7 @@ Function Get-CoreServiceSettings
 	Process { return Get-Settings; }
 }
 
-Function Set-CoreServiceSettings
+Function Set-TridionCoreServiceSettings
 {
     <#
     .Synopsis
@@ -282,7 +282,7 @@ Function Set-CoreServiceSettings
     }
 }
 
-Function Clear-CoreServiceSettings
+Function Clear-TridionCoreServiceSettings
 {
     <#
     .Synopsis
@@ -308,6 +308,6 @@ Function Clear-CoreServiceSettings
 * Export statements
 **************************************************
 #>
-Export-ModuleMember Get-CoreServiceSettings;
-Export-ModuleMember Set-CoreServiceSettings;
-Export-ModuleMember Clear-CoreServiceSettings;
+Export-ModuleMember Get-TridionCoreServiceSettings;
+Export-ModuleMember Set-TridionCoreServiceSettings;
+Export-ModuleMember Clear-TridionCoreServiceSettings;

--- a/CoreService/Tridion-CoreService.psd1
+++ b/CoreService/Tridion-CoreService.psd1
@@ -85,7 +85,5 @@ FileList = @("AppData.psm1", "Client.psm1", "Items.psm1", "Publishing.psm1", "Se
 
 # Private data to pass to the module specified in ModuleToProcess
 PrivateData = ''
-
-DefaultCommandPrefix = 'Tridion'
 }
 

--- a/CoreService/Trustees.psm1
+++ b/CoreService/Trustees.psm1
@@ -6,7 +6,7 @@
 **************************************************
 #>
 
-function Get-User
+function Get-TridionUser
 {
     <#
     .Synopsis
@@ -66,7 +66,7 @@ function Get-User
 
 	Begin
 	{
-        $client = Get-CoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
+        $client = Get-TridionCoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
 	}
     
     Process
@@ -88,7 +88,7 @@ function Get-User
 				}
 
 				Write-Verbose "Loading User with ID '$Id'..."
-				$result = Get-Item $Id -ErrorAction SilentlyContinue;
+				$result = Get-TridionItem $Id -ErrorAction SilentlyContinue;
 				if (-not $result)
 				{
 					Write-Error "User '$Id' does not exist.";
@@ -100,7 +100,7 @@ function Get-User
 			'ByTitle'
 			{
 				Write-Verbose "Loading User with title '$Title'..."
-				$result = Get-Users | ?{$_.Title -eq $Title} | Select -First 1;
+				$result = Get-TridionUsers | ?{$_.Title -eq $Title} | Select -First 1;
 				if (-not $result)
 				{
 					Write-Error "There is no User named '$Title'.";
@@ -112,7 +112,7 @@ function Get-User
 			'ByDescription'
 			{
 				Write-Verbose "Loading User with description '$Description'..."
-				$result = Get-Users | ?{$_.Description -eq $Description} | Select -First 1;
+				$result = Get-TridionUsers | ?{$_.Description -eq $Description} | Select -First 1;
 				if (-not $result)
 				{
 					Write-Error "There is no User with a description of '$Description'.";
@@ -125,11 +125,11 @@ function Get-User
 	
 	End
 	{
-		Close-CoreServiceClient $client;
+		Close-TridionCoreServiceClient $client;
 	}
 }
 
-function Get-Group
+function Get-TridionGroup
 {
     <#
     .Synopsis
@@ -188,7 +188,7 @@ function Get-Group
 				}
 
 				Write-Verbose "Loading Tridion Group with ID '$Id'..."
-				$result = Get-Item $Id -ErrorAction SilentlyContinue;
+				$result = Get-TridionItem $Id -ErrorAction SilentlyContinue;
 				if (-not $result)
 				{
 					Write-Error "Group '$Id' does not exist.";
@@ -200,7 +200,7 @@ function Get-Group
 			'ByTitle'
 			{
 				Write-Verbose "Loading Tridion Group with title '$Title'..."
-				$result = Get-Groups | ?{$_.Title -eq $Title} | Select -First 1;
+				$result = Get-TridionGroups | ?{$_.Title -eq $Title} | Select -First 1;
 				if (-not $result)
 				{
 					Write-Error "There is no Group named '$Title'.";
@@ -212,7 +212,7 @@ function Get-Group
 	}
 }
 
-Function Get-Users
+Function Get-TridionUsers
 {
     <#
     .Synopsis
@@ -261,7 +261,7 @@ Function Get-Users
 	
 	Begin
 	{
-        $client = Get-CoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
+        $client = Get-TridionCoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
 	}
 	
     Process
@@ -280,11 +280,11 @@ Function Get-Users
 	
 	End
 	{
-		Close-CoreServiceClient $client;
+		Close-TridionCoreServiceClient $client;
 	}
 }
 
-Function Get-Groups
+Function Get-TridionGroups
 {
     <#
     .Synopsis
@@ -313,7 +313,7 @@ Function Get-Groups
 	
 	Begin
 	{
-        $client = Get-CoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
+        $client = Get-TridionCoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
 	}
 	
     Process
@@ -328,11 +328,11 @@ Function Get-Groups
 	
 	End
 	{
-		Close-CoreServiceClient $client;
+		Close-TridionCoreServiceClient $client;
 	}
 }
 
-function New-Group
+function New-TridionGroup
 {
     <#
     .Synopsis
@@ -404,7 +404,7 @@ function New-Group
 	
 	Begin
 	{
-        $client = Get-CoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
+        $client = Get-TridionCoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
 	}
 
     Process
@@ -467,12 +467,12 @@ function New-Group
 	
 	End
 	{
-		Close-CoreServiceClient $client;
+		Close-TridionCoreServiceClient $client;
 	}	
 }
 
 
-function New-User
+function New-TridionUser
 {
     <#
     .Synopsis
@@ -549,7 +549,7 @@ function New-User
 	
 	Begin
 	{
-        $client = Get-CoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
+        $client = Get-TridionCoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
 		$tridionGroups = $null;
 		$groupsLoaded = $false;
 	}
@@ -593,7 +593,7 @@ function New-User
 							# It's not a URI, it's a name. Look up the group URI by its title.
 							if (-not $groupsLoaded)
 							{
-								$tridionGroups = Get-Groups
+								$tridionGroups = Get-TridionGroups
 								$groupsLoaded = $true;
 							}
 							
@@ -635,12 +635,12 @@ function New-User
 	
 	End
 	{
-		Close-CoreServiceClient $client;
+		Close-TridionCoreServiceClient $client;
 	}	
 }
 
 
-function Disable-User
+function Disable-TridionUser
 {
     <#
     .Synopsis
@@ -648,7 +648,7 @@ function Disable-User
 
     .Description
     Disables the specified user in Tridion Content Manager, preventing the user from logging in or performing any actions.
-    This action lasts until Enable-User is called or the user is explicitly enabled by other means (such as within the CME).
+    This action lasts until Enable-TridionUser is called or the user is explicitly enabled by other means (such as within the CME).
 
     .Inputs
     [string] Id: the TCM URI of the user.
@@ -683,7 +683,7 @@ function Disable-User
 	
 	Begin
 	{
-        $client = Get-CoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
+        $client = Get-TridionCoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
 	}
 
     Process
@@ -700,7 +700,7 @@ function Disable-User
 					return;
 				}
 				
-				$user = Get-Item -Id $Id -ErrorAction SilentlyContinue -Verbose:($PSBoundParameters['Verbose'] -eq $true);
+				$user = Get-TridionItem -Id $Id -ErrorAction SilentlyContinue -Verbose:($PSBoundParameters['Verbose'] -eq $true);
 				if ($user -eq $null) 
 				{ 
 					Write-Error "'$Id' is not a valid User.";
@@ -728,12 +728,12 @@ function Disable-User
 	
 	End
 	{
-		Close-CoreServiceClient $client;
+		Close-TridionCoreServiceClient $client;
 	}	
 }
 
 
-function Enable-User
+function Enable-TridionUser
 {
     <#
     .Synopsis
@@ -775,7 +775,7 @@ function Enable-User
 	
 	Begin
 	{
-        $client = Get-CoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
+        $client = Get-TridionCoreServiceClient -Verbose:($PSBoundParameters['Verbose'] -eq $true);
 	}
 
     Process
@@ -792,7 +792,7 @@ function Enable-User
 					return;
 				}
 				
-				$user = Get-Item -Id $Id -ErrorAction SilentlyContinue -Verbose:($PSBoundParameters['Verbose'] -eq $true);
+				$user = Get-TridionItem -Id $Id -ErrorAction SilentlyContinue -Verbose:($PSBoundParameters['Verbose'] -eq $true);
 				if ($user -eq $null) 
 				{ 
 					Write-Error "'$Id' is not a valid User.";
@@ -820,7 +820,7 @@ function Enable-User
 	
 	End
 	{
-		Close-CoreServiceClient $client;
+		Close-TridionCoreServiceClient $client;
 	}
 }
 
@@ -830,11 +830,11 @@ function Enable-User
 * Export statements
 **************************************************
 #>
-Export-ModuleMember Get-User
-Export-ModuleMember Get-Users
-Export-ModuleMember Get-Group
-Export-ModuleMember Get-Groups
-Export-ModuleMember New-Group
-Export-ModuleMember New-User
-Export-ModuleMember Disable-User
-Export-ModuleMember Enable-User
+Export-ModuleMember Get-TridionUser
+Export-ModuleMember Get-TridionUsers
+Export-ModuleMember Get-TridionGroup
+Export-ModuleMember Get-TridionGroups
+Export-ModuleMember New-TridionGroup
+Export-ModuleMember New-TridionUser
+Export-ModuleMember Disable-TridionUser
+Export-ModuleMember Enable-TridionUser


### PR DESCRIPTION
…as unfortunately it still causes conflicts with default cmdlets.

(e.g. Get-Item or New-Item would get overwritten with the Tridion functions despite using the Tridion prefix)

So the prefixes are now hardcoded again with the "prefix" they were documented as having (Tridion and Alchemy respectively)