### PR TITLE
Fix crash when installing and the user does not have a Documents folder

### DIFF
--- a/CoreService/Installation/Install-Local.ps1
+++ b/CoreService/Installation/Install-Local.ps1
@@ -28,7 +28,6 @@ function EnsureDirectoriesExist
 	# Locate the user's module directory
     $modulePaths = @($env:PSModulePath -split ';');
 	$expectedPath = Join-Path -Path ([Environment]::GetFolderPath('MyDocuments')) -ChildPath WindowsPowerShell\Modules;
-	$destination = ''
 	$myDocuments = [Environment]::GetFolderPath('MyDocuments')
 	
 	if ($myDocuments) {

--- a/CoreService/Installation/Install-Local.ps1
+++ b/CoreService/Installation/Install-Local.ps1
@@ -28,7 +28,13 @@ function EnsureDirectoriesExist
 	# Locate the user's module directory
     $modulePaths = @($env:PSModulePath -split ';');
 	$expectedPath = Join-Path -Path ([Environment]::GetFolderPath('MyDocuments')) -ChildPath WindowsPowerShell\Modules;
-	$destination = $modulePaths | Where-Object { $_ -eq $expectedPath } | Select -First 1;
+	$destination = ''
+	$myDocuments = [Environment]::GetFolderPath('MyDocuments')
+	
+	if ($myDocuments) {
+		$expectedPath = Join-Path -Path $myDocuments -ChildPath WindowsPowerShell\Modules;
+		$destination = $modulePaths | Where-Object { $_ -eq $expectedPath } | Select -First 1;
+	}
 	
 	if (-not $destination) 
 	{


### PR DESCRIPTION
In CoreService/Installation/Install-Local.ps1, the function EnsureDirectoriesExist crashes whenever the executing user does not have a Documents folder. This could happen when a machine user is used to automatically deploy into an environment.