### PR TITLE
Add check for readOptions parameter when calling GetDefaultData

### DIFF
--- a/CoreService/Items.psm1
+++ b/CoreService/Items.psm1
@@ -386,7 +386,15 @@ function New-TridionItem
     Process
     {
 		$readOptions = New-Object Tridion.ContentManager.CoreService.Client.ReadOptions;
-		$item = $client.GetDefaultData($ItemType, $Parent, $readOptions);
+
+		if ($client.GetDefaultData.OverloadDefinitions[0].IndexOf('ReadOptions readOptions') -gt 0)
+		{
+			$item = $client.GetDefaultData($ItemType, $Parent, $readOptions);
+		}
+		else
+		{
+			$item = $client.GetDefaultData($ItemType, $Parent);
+		}		
 		
 		if ($Title)
 		{


### PR DESCRIPTION
New-Tridion-Item crashes on Web-8.5, where GetDefaultData does not accept 3 parameters.