### PR TITLE
Updated Install.ps1 to included Workflow.psm1 - which is missing in t…

### DIFF
--- a/CoreService/Installation/Install.ps1
+++ b/CoreService/Installation/Install.ps1
@@ -25,7 +25,8 @@ $files = @(
 	'Settings.psm1', 
 	'Tridion-CoreService.psd1', 
 	'Trustees.psm1',
-	'Utilities.ps1'
+	'Utilities.ps1',
+	'Workflow.psm1'
 );
 
 


### PR DESCRIPTION
…his commit and failing

Import-Module : The module to process 'Workflow', listed in field 'NestedModules' of module manifest 
'C:\Users\vagrant\Documents\WindowsPowerShell\Modules\Tridion-CoreService\Tridion-CoreService.psd1' was not processed because no valid module was found in any module directory.
At line:50 char:2
+     Import-Module $ModuleName | Out-Null;
+     ~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ResourceUnavailable: (Tridion-CoreService:String) [Import-Module], PSInvalidOperationException
    + FullyQualifiedErrorId : Modules_ModuleFileNotFound,Microsoft.PowerShell.Commands.ImportModuleCommand